### PR TITLE
Add Hugo

### DIFF
--- a/pages/hugo.yml
+++ b/pages/hugo.yml
@@ -1,0 +1,61 @@
+
+# Sample workflow for building and deploying a Hugo site to GitHub Pages
+name: Deploy Hugo site to Pages
+
+on:
+  # Runs on push and pull request targetting the default branch
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.99.0
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Build with Hugo
+        run: |
+          hugo \
+            --minify \
+            --baseURL https://yoannchaudet.github.io/hugo/
+      - name: Upload artifact
+        uses: paper-spa/upload-pages-artifact@v0
+        with:
+          path: ./public
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@main

--- a/pages/hugo.yml
+++ b/pages/hugo.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Build with Hugo
         run: |
           hugo \
-            --minify \
-            --baseURL https://yoannchaudet.github.io/hugo/
+            --minify
+            # --baseURL https://yoannchaudet.github.io/hugo/
       - name: Upload artifact
         uses: paper-spa/upload-pages-artifact@v0
         with:


### PR DESCRIPTION
Add a workflow for Hugo.

Mostly inspired from @tcbyrd's example: https://github.com/tcbyrd/super-duper-bassoon/blob/010c88a4235cd221e06b7bcd33bbda359157691a/.github/workflows/hugo-pages.yml.

Major changes:

- Wording/comments to align further with https://github.com/paper-spa/starter-workflows/pull/1 (will make one final pass to normalize everything at the end)
- Hugo relies on submodules for themes typically so I enabled recursive checkout
- A lot of themes require a CSS processor (SaaS and co) so I switched to the extended version of Hugo (which contains the processor)
- Passed the `--minify` option since it's a good production default
- Temporarily hardcoded a base URL

Re base URL, we are going to have this problem with all static site generators... This is yet again our past of doing path based routing (but not only) biting us.

I think we should write an agnostic Actions that both enable Pages (if not done) in workflow mode and extract metadata about the Pages site (the URL would be sufficient for now). For Jekyll it is done with https://github.com/jekyll/github-metadata. But for other static site generators we could provide an extra step extracting the info and passing it as an output.