### PR TITLE
Cleanup all templates

### DIFF
--- a/pages/gatsby.yml
+++ b/pages/gatsby.yml
@@ -1,35 +1,47 @@
-name: 'Gatsby pages build'
+# Sample workflow for building and deploying a Gatsby site to GitHub Pages
+name: Deploy Gastby site to Pages
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
+  # Runs on push and pull request targetting the default branch
   push:
-    branches: [ master ]
+    branches: [$default-branch]
   pull_request:
-    branches: [ master ]
+    branches: [$default-branch]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# This sets the permissions of the GITHUB_TOKEN to allow us to deploy to Pages
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
 jobs:
+  # Build job
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Check package manager
-        id: check-package-manager
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Detect package manager
+        id: detect-package-manager
         run: |
           if [ -f "${{ github.workspace }}/yarn.lock" ]; then
             echo "::set-output name=manager::yarn"
             echo "::set-output name=command::install"
             exit 0
-          elif [  -f "${{ github.workspace }}/package-lock.json" ]; then
+          elif [ -f "${{ github.workspace }}/package-lock.json" ]; then
             echo "::set-output name=manager::npm"
             echo "::set-output name=command::ci"
             exit 0
@@ -37,16 +49,12 @@ jobs:
             echo "Unable to determine packager manager"
             exit 1
           fi
-
-        shell: bash
-
-      - uses: actions/setup-node@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
         with:
-          node-version: '16'
-          cache: ${{ steps.check-package-manager.outputs.manager }}
-
-      - name: cache gatsby site build
-        id: gatsby-cache-build
+          node-version: "16"
+          cache: ${{ steps.detect-package-manager.outputs.manager }}
+      - name: Restore cache
         uses: actions/cache@v2
         with:
           path: |
@@ -55,17 +63,16 @@ jobs:
           key: ${{ runner.os }}-gatsby-build-${{ hashFiles('public') }}
           restore-keys: |
             ${{ runner.os }}-gatsby-build-
-      - run: ${{ steps.check-package-manager.outputs.manager }} ${{ steps.check-package-manager.outputs.command }}
-        shell: bash
-
-      - run: ${{ steps.check-package-manager.outputs.manager }} run build --if-present
-        shell: bash
-      - name: Upload Pages artifact
-        uses: paper-spa/upload-pages-artifact@main
+      - name: Install dependencies
+        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+      - name: Build with Gatsby
+        run: ${{ steps.detect-package-manager.outputs.manager }} run build --if-present
+      - name: Upload artifact
+        uses: paper-spa/upload-pages-artifact@v0
         with:
-          path: 'public'
+          path: ./public
 
-  # The deploy job tells Pages to deploy the artifact we created in "build"
+  # Deployment job
   deploy:
     environment:
       name: github-pages
@@ -75,4 +82,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: paper-spa/deploy-pages@main
+        uses: actions/deploy-pages@v1

--- a/pages/hugo.yml
+++ b/pages/hugo.yml
@@ -1,13 +1,12 @@
-
 # Sample workflow for building and deploying a Hugo site to GitHub Pages
 name: Deploy Hugo site to Pages
 
 on:
   # Runs on push and pull request targetting the default branch
   push:
-    branches: [ $default-branch ]
+    branches: [$default-branch]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [$default-branch]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -22,6 +21,11 @@ permissions:
 concurrency:
   group: "pages"
   cancel-in-progress: true
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
 
 jobs:
   # Build job
@@ -58,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@main
+        uses: actions/deploy-pages@v1

--- a/pages/jekyll.yml
+++ b/pages/jekyll.yml
@@ -4,9 +4,9 @@ name: Deploy Jekyll site to Pages
 on:
   # Runs on push and pull request targetting the default branch
   push:
-    branches: [ $default-branch ]
+    branches: [$default-branch]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [$default-branch]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@main
+        uses: actions/deploy-pages@v1

--- a/pages/nextjs.yml
+++ b/pages/nextjs.yml
@@ -1,48 +1,65 @@
-# This is a basic workflow to help you get started with Actions
+# Sample workflow for building and deploying a Next.js site to GitHub Pages
+name: Deploy Next.js site to Pages
 
-name: nextjs
+on:
+  # Runs on push and pull request targetting the default branch
+  push:
+    branches: [$default-branch]
+  pull_request:
+    branches: [$default-branch]
 
-# This sets the permissions of the GITHUB_TOKEN to allow us to deploy to Pages
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Controls when the workflow will run
-on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This build job takes care of preparing the artifact that we'll deploy to Pages
+  # Build job
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '16'
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run build --if-present
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Detect package manager
+        id: detect-package-manager
+        run: |
+          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
+            echo "::set-output name=manager::yarn"
+            echo "::set-output name=command::install"
+            exit 0
+          elif [ -f "${{ github.workspace }}/package-lock.json" ]; then
+            echo "::set-output name=manager::npm"
+            echo "::set-output name=command::ci"
+            exit 0
+          else
+            echo "Unable to determine packager manager"
+            exit 1
+          fi
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          cache: ${{ steps.detect-package-manager.outputs.manager }}
+      - name: Install dependencies
+        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+      - name: Build with Next.js
+        run: ${{ steps.detect-package-manager.outputs.manager }} run build --if-present
+      - name: Upload artifact
+        uses: paper-spa/upload-pages-artifact@v0
+        with:
+          path: ./.next
 
-    - name: Upload Pages artifact
-      uses: paper-spa/upload-pages-artifact@main
-      with:
-        path: '.next/'
-
-  # The deploy job tells Pages to deploy the artifact we created in "build"
+  # Deployment job
   deploy:
-    if: ${{ always() }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -51,4 +68,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: paper-spa/deploy-pages@main
+        uses: actions/deploy-pages@v1

--- a/pages/nuxtjs.yml
+++ b/pages/nuxtjs.yml
@@ -1,49 +1,65 @@
-# This is a basic workflow to help you get started with Actions
+# Sample workflow for building and deploying a Nuxt site to GitHub Pages
+name: Deploy Nuxt site to Pages
 
-name: nuxtjs
+on:
+  # Runs on push and pull request targetting the default branch
+  push:
+    branches: [$default-branch]
+  pull_request:
+    branches: [$default-branch]
 
-# This sets the permissions of the GITHUB_TOKEN to allow us to deploy to Pages
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Controls when the workflow will run
-on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This build job takes care of preparing the artifact that we'll deploy to Pages
+  # Build job
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '16'
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run generate
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Detect package manager
+        id: detect-package-manager
+        run: |
+          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
+            echo "::set-output name=manager::yarn"
+            echo "::set-output name=command::install"
+            exit 0
+          elif [ -f "${{ github.workspace }}/package-lock.json" ]; then
+            echo "::set-output name=manager::npm"
+            echo "::set-output name=command::ci"
+            exit 0
+          else
+            echo "Unable to determine packager manager"
+            exit 1
+          fi
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          cache: ${{ steps.detect-package-manager.outputs.manager }}
+      - name: Install dependencies
+        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+      - name: Build with Nuxt
+        run: ${{ steps.detect-package-manager.outputs.manager }} run build --if-present
+      - name: Upload artifact
+        uses: paper-spa/upload-pages-artifact@v0
+        with:
+          path: ./dist
 
-
-    - name: Upload Pages artifact
-      uses: paper-spa/upload-pages-artifact@main
-      with:
-        path: 'dist/'
-
-  # The deploy job tells Pages to deploy the artifact we created in "build"
+  # Deployment job
   deploy:
-    if: ${{ always() }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -52,4 +68,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: paper-spa/deploy-pages@main
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
A lot of cleanup:

- wording (use same names everywhere)
- re-format all files
- for node base static site generators, detect package managers like we do for Gatsby
- add default shell so we can drop the `with: bash` everywhere
- snap to prod dependencies (`actions` org instead of `paper-spa`)