### PR TITLE
Use `base_url` output for Hugo configuration

### DIFF
--- a/pages/hugo.yml
+++ b/pages/hugo.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           hugo \
             --minify \
-            --baseURL ${{ steps.pages.outputs.origin }}
+            --baseURL ${{ steps.pages.outputs.base_url }}
       - name: Upload artifact
         uses: paper-spa/upload-pages-artifact@v0
         with:


### PR DESCRIPTION
Per the [Hugo docs](https://gohugo.io/getting-started/configuration/#baseurl), `baseURL` is:

> Hostname (and path) to the root, e.g. https://bep.is/

As such, we should probably pass in the output named `base_url` as it will include the `origin` _PLUS_ [potentially] the repository name path segment for project sites, e.g. `https://jamesmgreene.github.io/my-repo/`

---

❓ **QUESTION:** ❓ 
:warning: I'm curious if we should also be [setting the `canonifyURLs` flag](https://gohugo.io/getting-started/configuration/#canonifyurls) to true when there is a `base_path` other than `"/"`? 🤔 

➡️ It is not mentioned in [their article on hosting Hugo on GitHub Pages](https://gohugo.io/hosting-and-deployment/hosting-on-github/). 🤷🏻‍♂️ 