### PR TITLE
Use setup-ruby action instead of the docker image

### DIFF
--- a/pages/jekyll.yml
+++ b/pages/jekyll.yml
@@ -29,13 +29,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          source: ./
-          destination: ./_site
+          ruby-version: '3.0' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - run: bundle exec jekyll build # defaults output to '/_site'
       - name: Upload artifact
-        uses: paper-spa/upload-pages-artifact@v0
+        uses: paper-spa/upload-pages-artifact@v0 # This will automatically upload an artifact from the '/_site' directory
 
   # Deployment job
   deploy:


### PR DESCRIPTION
I was able to get this configuration working. Bundle install inside Actions is actually quite fast, and the setup-ruby action has automatic caching. The first run of this on my test repo did the whole bundle install and jekyll build in ~31 seconds. Subsequent runs were ~10-12 seconds, which is actually faster than downloading our docker image:

![image](https://user-images.githubusercontent.com/13207348/174415030-1b20ec42-b77b-4a7a-9722-f87f6c15d73a.png)

This also makes all our starter workflows aligned on a model where you use the tools of the framework to build, and can optionally add github-specific plugins (like the `github-pages` gem) to gain additional functionality.

cc @parkr since you might be interested in what we're doing here.