### PR TITLE
Add starter workflow for GitHub Pages's legacy Jekyll build

### DIFF
--- a/pages/jekyll-gh-pages.yml
+++ b/pages/jekyll-gh-pages.yml
@@ -1,0 +1,50 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll using the familiar GitHub Pages build process
+
+on:
+  # Runs on push and pull request targetting the default branch
+  push:
+    branches: [$default-branch]
+  pull_request:
+    branches: [$default-branch]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: paper-spa/upload-pages-artifact@v0
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/pages/properties/jekyll-gh-pages.yml
+++ b/pages/properties/jekyll-gh-pages.yml
@@ -1,0 +1,7 @@
+{
+    "name": "GitHub Pages Jekyll",
+    "creator": "GitHub Actions",
+    "description": "Package a Jekyll site using the familiar GitHub Pages build pipeline.",
+    "iconName": "jekyll-tube",
+    "categories": ["Pages"]
+}


### PR DESCRIPTION
Named `jekyll-gh-pages` so that it connotes the familiar "hands off"
build process of the Jekyll build as performed by github pages workers,
without sounding deprecated by using the words "legacy" or "classic".

Turns out this is simply copying over the existing Jekyll starter workflow.

I think it would be a good idea to commission a different icon for this workflow. Maybe one with both the Jekyll vial paired with a GitHub logo, or a GitHub Pages logo/mascot if we have one.