### PR TITLE
Perform static HTML export for Next.js

### DIFF
--- a/pages/nextjs.yml
+++ b/pages/nextjs.yml
@@ -38,7 +38,7 @@ jobs:
           elif [ -f "${{ github.workspace }}/package-lock.json" ]; then
             echo "::set-output name=manager::npm"
             echo "::set-output name=command::ci"
-            echo "::set-output name=runner::npx"
+            echo "::set-output name=runner::npx --no-install"
             exit 0
           else
             echo "Unable to determine packager manager"

--- a/pages/nextjs.yml
+++ b/pages/nextjs.yml
@@ -33,10 +33,12 @@ jobs:
           if [ -f "${{ github.workspace }}/yarn.lock" ]; then
             echo "::set-output name=manager::yarn"
             echo "::set-output name=command::install"
+            echo "::set-output name=runner::yarn"
             exit 0
           elif [ -f "${{ github.workspace }}/package-lock.json" ]; then
             echo "::set-output name=manager::npm"
             echo "::set-output name=command::ci"
+            echo "::set-output name=runner::npx"
             exit 0
           else
             echo "Unable to determine packager manager"
@@ -55,11 +57,13 @@ jobs:
         with:
           static_site_generator: next
       - name: Build with Next.js
-        run: ${{ steps.detect-package-manager.outputs.manager }} run build
+        run: ${{ steps.detect-package-manager.outputs.runner }} next build
+      - name: Static HTML export with Next.js
+        run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
         uses: paper-spa/upload-pages-artifact@v0
         with:
-          path: ./.next
+          path: ./out
 
   # Deployment job
   deploy:


### PR DESCRIPTION
For a typical Next.js application, you would build the site using `next build` but still be expected to run the _server_ using `next start` afterward. This will not work for hosting a Next.js application on GitHub Pages as we don't have a server aspect.

To support running a Next.js application as a static site, we need to _also_ run `next export` _after_ `next build` in order to [export the static HTML](https://nextjs.org/docs/advanced-features/static-html-export).

To avoid the likelihood of a `build` script not being configured as such in the `package.json` file, we should also invoke `next build` and `next export` more directly using `npx`/`yarn` (for local binary detection) rather than the current usage of `{npm|yarn} run build`.

---

Towards https://github.com/github/pages-engineering/issues/1337