### PR TITLE
Perform static HTML export for NuxtJS

### DIFF
--- a/pages/nuxtjs.yml
+++ b/pages/nuxtjs.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           static_site_generator: nuxt
       - name: Build with Nuxt
-        run: ${{ steps.detect-package-manager.outputs.manager }} run build
+        run: ${{ steps.detect-package-manager.outputs.manager }} run generate
       - name: Upload artifact
         uses: paper-spa/upload-pages-artifact@v0
         with:

--- a/pages/nuxtjs.yml
+++ b/pages/nuxtjs.yml
@@ -54,7 +54,7 @@ jobs:
         uses: paper-spa/configure-pages@main
         with:
           static_site_generator: nuxt
-      - name: Build with Nuxt
+      - name: Static HTML export with Nuxt
         run: ${{ steps.detect-package-manager.outputs.manager }} run generate
       - name: Upload artifact
         uses: paper-spa/upload-pages-artifact@v0


### PR DESCRIPTION
To host a Nuxt application as a static site, we need its starter workflow to run `{npm|yarn} run generate` (to run `nuxt generate`) to [export pre-rendered static HTML pages](https://nuxtjs.org/docs/get-started/commands/#static-deployment-pre-rendered) instead of `{npm|yarn} run build` as we are doing currently.

Nuxt guide for deploying to GitHub Pages: https://nuxtjs.org/deployments/github-pages

The success of this starter workflow may also depend on additional changes in the `configure-pages` Action: https://github.com/paper-spa/configure-pages/issues/9

---

Towards https://github.com/github/pages-engineering/issues/1337