### PR TITLE
Default to using npm if not using yarn

### DIFF
--- a/pages/gatsby.yml
+++ b/pages/gatsby.yml
@@ -39,7 +39,7 @@ jobs:
             echo "::set-output name=manager::yarn"
             echo "::set-output name=command::install"
             exit 0
-          else [ -f "${{ github.workspace }}/package.json" ]; then
+          elif [ -f "${{ github.workspace }}/package.json" ]; then
             echo "::set-output name=manager::npm"
             echo "::set-output name=command::ci"
             exit 0

--- a/pages/gatsby.yml
+++ b/pages/gatsby.yml
@@ -39,7 +39,7 @@ jobs:
             echo "::set-output name=manager::yarn"
             echo "::set-output name=command::install"
             exit 0
-          elif [ -f "${{ github.workspace }}/package-lock.json" ]; then
+          else [ -f "${{ github.workspace }}/package.json" ]; then
             echo "::set-output name=manager::npm"
             echo "::set-output name=command::ci"
             exit 0

--- a/pages/nextjs.yml
+++ b/pages/nextjs.yml
@@ -34,7 +34,7 @@ jobs:
             echo "::set-output name=manager::yarn"
             echo "::set-output name=command::install"
             exit 0
-          elif [ -f "${{ github.workspace }}/package-lock.json" ]; then
+          elif [ -f "${{ github.workspace }}/package.json" ]; then
             echo "::set-output name=manager::npm"
             echo "::set-output name=command::ci"
             exit 0

--- a/pages/nuxtjs.yml
+++ b/pages/nuxtjs.yml
@@ -34,7 +34,7 @@ jobs:
             echo "::set-output name=manager::yarn"
             echo "::set-output name=command::install"
             exit 0
-          elif [ -f "${{ github.workspace }}/package-lock.json" ]; then
+          elif [ -f "${{ github.workspace }}/package.json" ]; then
             echo "::set-output name=manager::npm"
             echo "::set-output name=command::ci"
             exit 0


### PR DESCRIPTION
The NuxtJS starter application I used for [`paper-spa/starter-test-nuxtjs`](https://github.com/paper-spa/starter-test-nuxtjs) did not contain a `package-lock.json` nor `yarn-lock.json` file.

As such, our starter workflow failed to detect the relevant package manager:

https://github.com/paper-spa/starter-test-nuxtjs/runs/7125427496?check_suite_focus=true#step:3:17

I suggest that, for all of the Node.js-based starter workflows, we default to using `npm` so long as a `yarn-lock.json` file does NOT exist (and a `package.json` file DOES exist). 🤔 

---

ℹ️  **Note:** If we don't agree on this approach, the problem can still be pretty easily worked around by the user... they just need to run an `{npm|yarn} install` the first time to generate the relevant lock file. 🤷🏻‍♂️ 

---

Towards https://github.com/github/pages-engineering/issues/1337