### PR TITLE
Add configure-pages step to static workflow

### DIFF
--- a/pages/static.yml
+++ b/pages/static.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: paper-spa/configure-pages@main
       - name: Upload artifact
         uses: paper-spa/upload-pages-artifact@v0
         with:


### PR DESCRIPTION
Our `static` starter workflow did not include the `configure-pages` step as it isn't _really_ necessary. However, without it, at least the first workflow run might fail because Pages may not yet be enabled for the repository.

<img width="1077" alt="image" src="https://user-images.githubusercontent.com/417751/178366429-82120c0c-5ec0-4883-9f44-43304afc0391.png">
