### PR TITLE
Add configuration step to enable Pages

### DIFF
--- a/pages/jekyll-gh-pages.yml
+++ b/pages/jekyll-gh-pages.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: paper-spa/configure-pages@main
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:


### PR DESCRIPTION
Similar to #20, the Jekyll (GitHub Pages) starter workflow fails initially if Pages is not enabled.

To resolve this, add a `configure-pages` step first. ⚙️  