### PR TITLE
Pages: Set `PREFIX_PATHS` env var for Gatsby build

### DIFF
--- a/pages/gatsby.yml
+++ b/pages/gatsby.yml
@@ -69,6 +69,8 @@ jobs:
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Gatsby
+        env:
+          PREFIX_PATHS: 'true'
         run: ${{ steps.detect-package-manager.outputs.manager }} run build
       - name: Upload artifact
         uses: paper-spa/upload-pages-artifact@v0


### PR DESCRIPTION
Without this change, our Gatsby build is not honoring the `pathPrefix` that `configure-pages` is adding to its configuration file:

https://github.com/paper-spa/starter-test-gatsby/runs/7365079932?check_suite_focus=true

<img width="952" alt="image" src="https://user-images.githubusercontent.com/417751/179312822-50c93d34-35a4-412f-b975-7fdff4d150e9.png">

Turns out that is because we not only need to add the `pathPrefix` configuration, but we **also** need to [run the Gatsby build](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/#build) with the command line flag `--prefix-paths` or the environment variable `PREFIX_PATHS=true`. Since our Gatsby starter workflow is calling `{npm|yarn} run build` rather than invoking `gatsby build` directly, I opted to set the environment variable.