### PR TITLE
Update NuxtJS starter workflow to cache builds

### DIFF
--- a/pages/nuxtjs.yml
+++ b/pages/nuxtjs.yml
@@ -47,13 +47,22 @@ jobs:
         with:
           node-version: "16"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
-      - name: Install dependencies
-        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Setup Pages
         id: pages
         uses: paper-spa/configure-pages@main
         with:
           static_site_generator: nuxt
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            dist
+            .nuxt
+          key: ${{ runner.os }}-nuxt-build-${{ hashFiles('dist') }}
+          restore-keys: |
+            ${{ runner.os }}-nuxt-build-
+      - name: Install dependencies
+        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Static HTML export with Nuxt
         run: ${{ steps.detect-package-manager.outputs.manager }} run generate
       - name: Upload artifact


### PR DESCRIPTION
Basically modeled after the Gatsby starter workflow: https://github.com/paper-spa/starter-workflows/blob/79f47ef04f7677f8e519679ede6d708b7641b4fd/pages/gatsby.yml#L60-L68