### PR TITLE
Retarget actions referencing `paper-spa` to `actions`

### DIFF
--- a/pages/gatsby.yml
+++ b/pages/gatsby.yml
@@ -57,7 +57,7 @@ jobs:
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         id: pages
-        uses: paper-spa/configure-pages@main
+        uses: actions/configure-pages@v1
         with:
           # Automatically inject pathPrefix in your Gatsby configuration file.
           # You may remove this line if you want to manage the configuration yourself.
@@ -78,7 +78,7 @@ jobs:
           PREFIX_PATHS: 'true'
         run: ${{ steps.detect-package-manager.outputs.manager }} run build
       - name: Upload artifact
-        uses: paper-spa/upload-pages-artifact@v0
+        uses: actions/upload-pages-artifact@v1
         with:
           path: ./public
 

--- a/pages/hugo.yml
+++ b/pages/hugo.yml
@@ -42,14 +42,14 @@ jobs:
           submodules: recursive
       - name: Setup Pages
         id: pages
-        uses: paper-spa/configure-pages@main
+        uses: actions/configure-pages@v1
       - name: Build with Hugo
         run: |
           hugo \
             --minify \
             --baseURL ${{ steps.pages.outputs.base_url }}
       - name: Upload artifact
-        uses: paper-spa/upload-pages-artifact@v0
+        uses: actions/upload-pages-artifact@v1
         with:
           path: ./public
 

--- a/pages/jekyll-gh-pages.yml
+++ b/pages/jekyll-gh-pages.yml
@@ -28,14 +28,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Pages
-        uses: paper-spa/configure-pages@main
+        uses: actions/configure-pages@v1
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: paper-spa/upload-pages-artifact@v0
+        uses: actions/upload-pages-artifact@v1
 
   # Deployment job
   deploy:

--- a/pages/jekyll.yml
+++ b/pages/jekyll.yml
@@ -35,10 +35,10 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: paper-spa/configure-pages@main
+        uses: actions/configure-pages@v1
       - run: bundle exec jekyll build --baseurl ${{ steps.pages.outputs.base_path }} # defaults output to '/_site'
       - name: Upload artifact
-        uses: paper-spa/upload-pages-artifact@v0 # This will automatically upload an artifact from the '/_site' directory
+        uses: actions/upload-pages-artifact@v1 # This will automatically upload an artifact from the '/_site' directory
 
   # Deployment job
   deploy:

--- a/pages/nextjs.yml
+++ b/pages/nextjs.yml
@@ -54,7 +54,7 @@ jobs:
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         id: pages
-        uses: paper-spa/configure-pages@main
+        uses: actions/configure-pages@v1
         with:
           # Automatically inject basePath in your Next.js configuration file and disable
           # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
@@ -77,7 +77,7 @@ jobs:
       - name: Static HTML export with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
-        uses: paper-spa/upload-pages-artifact@v0
+        uses: actions/upload-pages-artifact@v1
         with:
           path: ./out
 

--- a/pages/nuxtjs.yml
+++ b/pages/nuxtjs.yml
@@ -52,7 +52,7 @@ jobs:
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         id: pages
-        uses: paper-spa/configure-pages@main
+        uses: actions/configure-pages@v1
         with:
           # Automatically inject router.base in your Nuxt configuration file.
           # You may remove this line if you want to manage the configuration yourself.
@@ -71,7 +71,7 @@ jobs:
       - name: Static HTML export with Nuxt
         run: ${{ steps.detect-package-manager.outputs.manager }} run generate
       - name: Upload artifact
-        uses: paper-spa/upload-pages-artifact@v0
+        uses: actions/upload-pages-artifact@v1
         with:
           path: ./dist
 

--- a/pages/static.yml
+++ b/pages/static.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Pages
-        uses: paper-spa/configure-pages@main
+        uses: actions/configure-pages@v1
       - name: Upload artifact
-        uses: paper-spa/upload-pages-artifact@v0
+        uses: actions/upload-pages-artifact@v1
         with:
           # Upload entire repository
           path: '.'


### PR DESCRIPTION
Also point to newly published `v1` tags rather than `main` or `v0`.

`actions/configure-pages` is at tag `v1` here: https://github.com/actions/configure-pages/tree/v1
`actions/upload-pages-artifact` is at tag `v1` here: https://github.com/actions/upload-pages-artifact/tree/v1

For BYOW release checklist https://github.com/github/pages-engineering/issues/1402